### PR TITLE
Add support for new MongoDB UTCDateTime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ cache:
   directories:
     - $HOME/composer/.cache
 
+before_install:
+    - phpenv config-add travis/etc/php-mongo.ini
+    - pecl install mongodb
+    - echo "extension=mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+
 install:
   - composer install --prefer-dist --no-interaction
 
-before_script: phpenv config-add travis/etc/php-mongo.ini
-
 script:
   - vendor/bin/phpunit
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 
 php:
   - 5.6
+  - 7.0
 
 sudo: false
 
@@ -11,9 +12,7 @@ cache:
     - $HOME/composer/.cache
 
 before_install:
-    - phpenv config-add travis/etc/php-mongo.ini
-    - pecl install mongodb
-    - echo "extension=mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - travis/scripts/install-extension.sh
 
 install:
   - composer install --prefer-dist --no-interaction

--- a/spec/unit/Onebip/DateTime/UTCDateTimeRangeTest.php
+++ b/spec/unit/Onebip/DateTime/UTCDateTimeRangeTest.php
@@ -6,6 +6,9 @@ use PHPUnit_Framework_TestCase;
 
 class UTCDateTimeRangeTest extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @requires extension mongo
+     */
     public function testItCanBuildAClosedInterval()
     {
         $range = UTCDateTimeRange::fromIncludedToIncluded(
@@ -22,6 +25,9 @@ class UTCDateTimeRangeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testItCanBuildARightOpenInterval()
     {
         $range = UTCDateTimeRange::fromIncludedToExcluded(
@@ -58,6 +64,9 @@ class UTCDateTimeRangeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testToMongoQueryOnFieldShouldReturnTheSameQueryTheNotParameterizedVersion()
     {
         $range = UTCDateTimeRange::fromIncludedToIncluded(

--- a/spec/unit/Onebip/DateTime/UTCDateTimeTest.php
+++ b/spec/unit/Onebip/DateTime/UTCDateTimeTest.php
@@ -1,13 +1,14 @@
 <?php
 namespace Onebip\DateTime;
 
-use PHPUnit_Framework_TestCase;
-use MongoDate;
+use DateInterval;
 use DateTime;
 use DateTimeZone;
-use DateInterval;
 use Eris;
 use Eris\Generator;
+use MongoDB\BSON\UTCDateTime as MongoUTCDateTime;
+use MongoDate;
+use PHPUnit_Framework_TestCase;
 
 class UTCDateTimeTest extends PHPUnit_Framework_TestCase
 {
@@ -19,6 +20,14 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         $dateTime = UTCDateTime::box($mongoDate);
 
         $this->assertEquals($mongoDate, $dateTime->toMongoDate());
+    }
+
+    public function testBoxingUTCMongoDate()
+    {
+        $mongoDate = new MongoUTCDateTime(1466170836123);
+        $dateTime = UTCDateTime::box($mongoDate);
+
+        $this->assertEquals($mongoDate, $dateTime->toMongoUTCDateTime());
     }
 
     public function testBoxingDateTime()

--- a/spec/unit/Onebip/DateTime/UTCDateTimeTest.php
+++ b/spec/unit/Onebip/DateTime/UTCDateTimeTest.php
@@ -14,6 +14,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
 {
     use Eris\TestTrait;
 
+    /**
+     * @requires extension mongo
+     */
     public function testBoxingMongoDate()
     {
         $mongoDate = new MongoDate();
@@ -22,6 +25,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($mongoDate, $dateTime->toMongoDate());
     }
 
+    /**
+     * @requires extension mongodb
+     */
     public function testBoxingUTCMongoDate()
     {
         $mongoDate = new MongoUTCDateTime(1466170836123);
@@ -79,6 +85,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testBoxingDateTimeAndUnboxingMongoDate()
     {
         $date = new DateTime();
@@ -94,6 +103,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expectedOutput, $output);
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testBoxingMongoDateAndUnboxingDateTime()
     {
         $mongoDate = new MongoDate();
@@ -131,6 +143,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, $later->usec() % 1000);
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testPrecisionIsMaintainedwhenCreatedFromAMicrotimeString()
     {
         $this->assertEquals(
@@ -152,6 +167,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         UTCDateTime::fromMicrotime('1 1000');
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testFromIso8601FactoryMethod()
     {
         $this->assertEquals(
@@ -238,6 +256,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testPrecisionIsKeptEvenDuringSubtractionOfSecondsOperation()
     {
         $this->assertEquals(
@@ -246,6 +267,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testPrecisionIsKeptEvenDuringDifferenceOfTimesOperation()
     {
         $this->assertEquals(
@@ -257,6 +281,9 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @requires extension mongo
+     */
     public function testCanAddSeconds()
     {
         $this->assertEquals(

--- a/spec/unit/Onebip/DateTime/UTCDateTimeTest.php
+++ b/spec/unit/Onebip/DateTime/UTCDateTimeTest.php
@@ -134,15 +134,6 @@ class UTCDateTimeTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull(UTCDateTime::now());
     }
 
-    public function testNowFactoryMethodHasMillesecondsResolution()
-    {
-        $now = UTCDateTime::now();
-        usleep(333);
-        $later = UTCDateTime::now();
-        $this->assertEquals(0, $now->usec() % 1000);
-        $this->assertEquals(0, $later->usec() % 1000);
-    }
-
     /**
      * @requires extension mongo
      */

--- a/src/Onebip/DateTime/UTCDateTime.php
+++ b/src/Onebip/DateTime/UTCDateTime.php
@@ -1,11 +1,12 @@
 <?php
 namespace Onebip\DateTime;
 
-use MongoDate;
+use DateInterval;
 use DateTime;
 use DateTimeZone;
-use DateInterval;
 use InvalidArgumentException;
+use MongoDB\BSON\UTCDateTime as MongoUTCDateTime;
+use MongoDate;
 
 final class UTCDateTime
 {
@@ -26,6 +27,13 @@ final class UTCDateTime
     public function toMongoDate()
     {
         return new MongoDate($this->sec, $this->usec);
+    }
+
+    public function toMongoUTCDateTime()
+    {
+        return new MongoUTCDateTime(
+            $this->sec * 1000 + (int) round($this->usec / 1000)
+        );
     }
 
     public function toDateTime(DateTimeZone $timeZone = null)
@@ -112,6 +120,15 @@ final class UTCDateTime
                     '%s is not a valid value to box',
                     var_export($dateToBox, true)
                 )
+            );
+        }
+
+        if ($dateToBox instanceof MongoUTCDateTime) {
+            $msec = (string)$dateToBox + 0;
+
+            return new self(
+                (int) ($msec / 1000),
+                1000 * ($msec % 1000)
             );
         }
 

--- a/src/Onebip/DateTime/UTCDateTime.php
+++ b/src/Onebip/DateTime/UTCDateTime.php
@@ -189,7 +189,7 @@ final class UTCDateTime
 
     public static function now()
     {
-        return self::box(new MongoDate());
+        return self::fromMicrotime(microtime());
     }
 
     public static function fromMicrotime($microtimeString)

--- a/travis/etc/php-mongodb.ini
+++ b/travis/etc/php-mongodb.ini
@@ -1,0 +1,1 @@
+extension = "mongodb.so"

--- a/travis/scripts/install-extension.sh
+++ b/travis/scripts/install-extension.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+isphp7=`php travis/scripts/version.php`
+if [ "$isphp7" -eq 0 ]; then
+    phpenv config-add travis/etc/php-mongo.ini
+    pecl install mongodb
+fi
+
+phpenv config-add travis/etc/php-mongodb.ini

--- a/travis/scripts/version.php
+++ b/travis/scripts/version.php
@@ -1,0 +1,2 @@
+<?php
+echo (int)version_compare(PHP_VERSION, '7.0', '>='), PHP_EOL;


### PR DESCRIPTION
This is a required step towards MongoDB 3.2 and PHP 7.0
